### PR TITLE
set CMAKE_BUILD_TYPE in CMakeLists.txt instead

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# set default build type
+if (NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif ()
+
 # enable LTO/IPO in release builds
 include(CheckIPOSupported)
 check_ipo_supported(RESULT ipo_supported)

--- a/Justfile
+++ b/Justfile
@@ -2,7 +2,6 @@ export CC               := ""
 export CXX              := ""
 export CXXFLAGS         := ""
 export LDFLAGS          := ""
-export CMAKE_BUILD_TYPE := env("CMAKE_BUILD_TYPE", "Debug")
 
 default:
   just --list


### PR DESCRIPTION
this sets `CMAKE_BUILD_TYPE` even if you're not using the `Justfile`, which is nice for VSCode.