### PR TITLE
install binaries into result/bin again

### DIFF
--- a/nix/sbokena.nix
+++ b/nix/sbokena.nix
@@ -108,8 +108,10 @@ in
 
     installPhase = ''
       runHook preInstall
-      install -dm755 $out
-      cp -r build/* $out
+      install -Dm755 \
+        build/editor/editor \
+        build/game/game \
+        -t $out/bin
       runHook postInstall
     '';
 


### PR DESCRIPTION
i decided at some point to move the entire `build/` folder into the output (i guess to split out checks???) but that's not needed anymore.