### PR TITLE
make checks.sbokena use the debug build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,19 +49,18 @@
 
         # miscellaneous checks, run with `nix flake check`
         checks = let
-          sbokena =
+          sbokena-debug =
             pkgs.callPackage
             ./nix/sbokena.nix
-            {};
+            {buildRelease = false;};
         in {
           format =
             pkgs.callPackage
             ./nix/checks/format.nix
             {};
 
-          sbokena =
-            sbokena.overrideAttrs
-            {doCheck = true;};
+          sbokena = sbokena-debug
+            .overrideAttrs {doCheck = true;};
         };
       };
     };

--- a/nix/sbokena.nix
+++ b/nix/sbokena.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   lib,
+  buildRelease ? true,
   enableWayland ? true,
   enableX11 ? true,
   ...
@@ -91,7 +92,11 @@ in
 
     cmakeFlags =
       [
-        "-DCMAKE_BUILD_TYPE=Release"
+        (lib.cmakeFeature "CMAKE_BUILD_TYPE" (
+          if buildRelease
+          then "Release"
+          else "Debug"
+        ))
         (lib.cmakeBool "GLFW_BUILD_WAYLAND" enableWayland)
         (lib.cmakeBool "GLFW_BUILD_X11" enableX11)
       ]


### PR DESCRIPTION
previously the Nix flake always uses the `Release` build type, which skips all of the sanitizers and everything i've set up for testing; this should make it work properly.