### PR TITLE
general: make building tests optional

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -30,6 +30,6 @@ lint *args: (cmake args)
     $(fd -E build -F '.cc') \
     $(fd -E build -F '.hh')
 
-test *args: (build args)
+test *args: (build args "-DBUILD_TESTS=1")
   ctest --test-dir build/tests \
     {{args}}

--- a/nix/sbokena.nix
+++ b/nix/sbokena.nix
@@ -141,7 +141,7 @@
       ];
     };
 in
-  clangStdenv.mkDerivation {
+  clangStdenv.mkDerivation (finalAttrs: {
     name = "sbokena";
     src = ../.;
     strictDeps = true;
@@ -158,6 +158,9 @@ in
           select buildRelease "Release" "Debug"
         ))
       ]
+      ++ lib.optionals finalAttrs.doCheck [
+        (lib.cmakeBool "BUILD_TESTS" true)
+      ]
       ++ lib.optionals isLinux [
         (lib.cmakeBool "GLFW_BUILD_WAYLAND" enableWayland')
         (lib.cmakeBool "GLFW_BUILD_X11" enableX11')
@@ -171,6 +174,7 @@ in
       cmake --build build
     '';
 
+    doCheck = false;
     checkPhase = ''
       clang-tidy -p build \
         $(fd -E build/ -F '.cc') \
@@ -195,4 +199,4 @@ in
 
     # passthru env-vars for shell
     passthru.env = env;
-  }
+  })

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,16 +1,36 @@
-enable_testing()
+if (BUILD_TESTS)
+  include(FetchContent)
 
-file(GLOB SOURCES_CXX "*.cc")
-set(SOURCES ${SOURCES_CXX})
+  enable_testing()
 
-add_executable(tests)
-target_sources(tests PRIVATE ${SOURCES})
-target_link_libraries(tests PRIVATE
-  GTest::gtest_main
-  nlohmann_json::nlohmann_json
-  common
-  libgame
-)
+  if (DEFINED ENV{GOOGLETEST_SRC})
+    FetchContent_Declare(
+      googletest
+      SOURCE_DIR $ENV{GOOGLETEST_SRC}
+      SYSTEM
+    )
+  else ()
+    FetchContent_Declare(
+      googletest
+      GIT_REPOSITORY "https://github.com/google/googletest"
+      GIT_TAG v1.17.0
+      SYSTEM
+    )
+  endif ()
+  FetchContent_MakeAvailable(googletest)
 
-include(GoogleTest)
-gtest_discover_tests(tests)
+  file(GLOB SOURCES_CXX "*.cc")
+  set(SOURCES ${SOURCES_CXX})
+
+  add_executable(tests)
+  target_sources(tests PRIVATE ${SOURCES})
+  target_link_libraries(tests PRIVATE
+    GTest::gtest_main
+    nlohmann_json::nlohmann_json
+    common
+    libgame
+  )
+
+  include(GoogleTest)
+  gtest_discover_tests(tests)
+endif ()

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -1,20 +1,5 @@
 include(FetchContent)
 
-if (DEFINED ENV{GOOGLETEST_SRC})
-  FetchContent_Declare(
-    googletest
-    SOURCE_DIR $ENV{GOOGLETEST_SRC}
-    SYSTEM
-  )
-else ()
-  FetchContent_Declare(
-    googletest
-    GIT_REPOSITORY "https://github.com/google/googletest"
-    GIT_TAG v1.17.0
-    SYSTEM
-  )
-endif ()
-
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set(NFD_PORTAL 1)
 endif ()
@@ -106,7 +91,6 @@ else ()
 endif ()
 
 FetchContent_MakeAvailable(
-  googletest
   nfd
   nlohmann_json
   raylib


### PR DESCRIPTION
building tests is now optional, gated by the CMake option `BUILD_TESTS`.
adjusted `just test` to set this new option.